### PR TITLE
Refine Android usage and analytics handling

### DIFF
--- a/apps/mobile-android/app/src/main/AndroidManifest.xml
+++ b/apps/mobile-android/app/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="com.example.emt">
+    xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.INTERNET" />

--- a/apps/mobile-android/app/src/main/java/com/example/emt/ui/MainScreen.kt
+++ b/apps/mobile-android/app/src/main/java/com/example/emt/ui/MainScreen.kt
@@ -3,7 +3,7 @@ package com.example.emt.ui
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
-import androidx.compose.material.icons.filled.Analytics
+import androidx.compose.material.icons.filled.Insights
 import androidx.compose.material.icons.filled.List
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.*
@@ -26,7 +26,7 @@ import com.example.emt.ui.usage.ViewModelFactory
 sealed class Screen(val route: String, val label: String, val icon: ImageVector) {
     object History : Screen("history", "History", Icons.Default.List)
     object Add : Screen("add", "Add", Icons.Default.Add)
-    object Analytics : Screen("analytics", "Analytics", Icons.Default.Analytics)
+    object Analytics : Screen("analytics", "Analytics", Icons.Default.Insights)
     object Settings : Screen("settings", "Settings", Icons.Default.Settings)
 }
 
@@ -42,6 +42,7 @@ fun MainScreen(app: EMTApplication) {
     val analyticsViewModel: AnalyticsViewModel = viewModel(
         factory = AnalyticsViewModelFactory(app.usageRepository)
     )
+    val usages by usageViewModel.allUsages.collectAsState()
     var currentScreen by remember { mutableStateOf<Screen>(Screen.History) }
 
     Scaffold(
@@ -61,7 +62,11 @@ fun MainScreen(app: EMTApplication) {
     ) { innerPadding ->
         Surface(modifier = Modifier.padding(innerPadding)) {
             when (currentScreen) {
-                is Screen.History -> HistoryScreen(usageViewModel)
+                is Screen.History -> HistoryScreen(
+                    items = usages,
+                    onEdit = { usageViewModel.updateUsage(it) },
+                    onDelete = { usageViewModel.deleteUsage(it) }
+                )
                 is Screen.Add -> AddReadingScreen(usageViewModel)
                 is Screen.Analytics -> AnalyticsScreen(analyticsViewModel)
                 is Screen.Settings -> SettingsScreen(settingsViewModel)

--- a/apps/mobile-android/app/src/main/java/com/example/emt/ui/analytics/AnalyticsScreen.kt
+++ b/apps/mobile-android/app/src/main/java/com/example/emt/ui/analytics/AnalyticsScreen.kt
@@ -9,6 +9,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import java.text.SimpleDateFormat
+import java.util.Locale
 
 @Composable
 fun AnalyticsScreen(viewModel: AnalyticsViewModel) {

--- a/apps/mobile-android/app/src/main/java/com/example/emt/ui/analytics/AnalyticsViewModel.kt
+++ b/apps/mobile-android/app/src/main/java/com/example/emt/ui/analytics/AnalyticsViewModel.kt
@@ -8,6 +8,8 @@ import com.example.emt.data.UsageRepository
 import kotlinx.coroutines.flow.*
 import java.util.Calendar
 import java.util.Date
+import java.text.SimpleDateFormat
+import java.util.Locale
 
 data class AnalyticsUiState(
     val totalKwhThisMonth: Double = 0.0,

--- a/apps/mobile-android/app/src/main/java/com/example/emt/ui/usage/AddReadingScreen.kt
+++ b/apps/mobile-android/app/src/main/java/com/example/emt/ui/usage/AddReadingScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.launch
+import java.util.Calendar
 import java.util.Date
 
 @OptIn(ExperimentalMaterial3Api::class)

--- a/apps/mobile-android/app/src/main/java/com/example/emt/ui/usage/HistoryScreen.kt
+++ b/apps/mobile-android/app/src/main/java/com/example/emt/ui/usage/HistoryScreen.kt
@@ -57,7 +57,7 @@ fun HistoryScreen(
                         // Optional: simple feedback snackbar
                         scope.launch {
                             snackbarHostState.showSnackbar(
-                                "Deleted ${formatDate(usage.date)} (${formatKwh(usage.kWh)})"
+                                "Deleted ${formatDate(usage.date.time)} (${formatKwh(usage.kwh)})"
                             )
                         }
                     }
@@ -83,11 +83,11 @@ private fun HistoryRow(
         ) {
             Column(modifier = Modifier.weight(1f)) {
                 Text(
-                    text = formatDate(item.date),
+                    text = formatDate(item.date.time),
                     style = MaterialTheme.typography.titleMedium
                 )
                 Text(
-                    text = formatKwh(item.kWh),
+                    text = formatKwh(item.kwh),
                     style = MaterialTheme.typography.bodyMedium
                 )
             }

--- a/apps/mobile-android/app/src/main/java/com/example/emt/workers/BootReceiver.kt
+++ b/apps/mobile-android/app/src/main/java/com/example/emt/workers/BootReceiver.kt
@@ -14,9 +14,10 @@ class BootReceiver : BroadcastReceiver() {
         if (intent.action == Intent.ACTION_BOOT_COMPLETED) {
             val settingsRepository = SettingsRepository(context)
             CoroutineScope(Dispatchers.IO).launch {
-                val settings = settingsRepository.settings.first()
-                if (settings.isReminderEnabled) {
-                    ReminderScheduler.scheduleReminder(context, settings.reminderTime)
+                val enabled = settingsRepository.remindersEnabledFlow.first()
+                val time = settingsRepository.reminderTimeFlow.first()
+                if (enabled) {
+                    ReminderScheduler.scheduleReminder(context, time)
                 }
             }
         }

--- a/apps/mobile-android/app/src/test/java/com/example/emt/AnalyticsViewModelTest.kt
+++ b/apps/mobile-android/app/src/test/java/com/example/emt/AnalyticsViewModelTest.kt
@@ -11,6 +11,7 @@ import org.mockito.Mockito.`when`
 import org.mockito.Mockito.mock
 import java.util.Calendar
 import java.util.Date
+import java.text.SimpleDateFormat
 
 class AnalyticsViewModelTest {
 
@@ -67,6 +68,7 @@ class AnalyticsViewModelTest {
         assertEquals(15.0, result.chartData.find { it.first.contains(date1Str) }?.second, 0.01)
         assertEquals(8.0, result.chartData.find { it.first.contains(date2Str) }?.second, 0.01)
         assertEquals(12.0, result.chartData.find { it.first.contains(date3Str) }?.second, 0.01)
+    }
 
     @Test
     fun calculateAnalytics_emptyList_returnsZeros() {


### PR DESCRIPTION
## Summary
- remove explicit package declaration from manifest
- fix HistoryScreen kwh field and date handling
- pass UsageViewModel data to HistoryScreen and use Insights icon
- add missing imports for analytics and usage screens
- schedule reminders using SettingsRepository flows and close test brace

## Testing
- `./gradlew --no-daemon :app:assembleDebug :app:testDebugUnitTest :app:lintDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a530d5eea8832384ad6ffce033fcc4