### PR TITLE
ci: refine android workflow triggers

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,10 +1,12 @@
 name: Android Debug Build
 
 on:
-  push:
-    branches: ["**"]
-  pull_request:
+  pull_request: { types: [opened, synchronize, reopened] }
   workflow_dispatch:
+
+concurrency:
+  group: android-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:
@@ -69,9 +71,7 @@ jobs:
           cat gradle.properties
 
       - name: Build & Test
-        run: |
-          ./gradlew --version
-          ./gradlew --no-daemon clean :app:test :app:assembleDebug
+        run: ./gradlew --no-daemon :app:assembleDebug :app:testDebugUnitTest :app:lintDebug
 
       - name: Upload APK
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- limit Android workflow to pull requests and manual runs
- serialize concurrent Android workflow runs
- simplify build step to assemble, test, and lint

## Testing
- `bash ./scripts/smoke.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a533aff1bc8323868b069b5d36ddee